### PR TITLE
fix(prisma): Switch Prisma generator to prisma-client-js

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -5,7 +5,7 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client"
+  provider = "prisma-client-js"
   output   = "../src/generated/prisma"
 }
 


### PR DESCRIPTION
Update schema.prisma to use the correct generator provider name: changed provider from "prisma-client" to "prisma-client-js". Output path remains ../src/generated/prisma. This aligns the schema with the current Prisma client package naming to ensure the client is generated correctly.